### PR TITLE
Install AWS CLI into gitpod tasks

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,13 @@
-
+tasks:
+  - name: aws-cli
+    env:
+      AWS_CLI_AUTO_PROMPT: on-partial
+    init: |
+      cd /workspace
+      curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      unzip awscliv2.zip
+      sudo ./aws/install
+      cd $THEIA_WORKSPACE_ROOT
 vscode:
   extensions:
     - 42Crunch.vscode-openapi


### PR DESCRIPTION
I have successfully installed AWS Cli into Gitpod. I did in week 0 but I think I didn't commit it or mistakenly deleted it.
![Screenshot from 2023-03-03 16-29-16](https://user-images.githubusercontent.com/120579796/222786013-ccfad023-ebc9-48ba-8046-a7d36bc92033.png)
![Screenshot from 2023-03-03 17-08-26](https://user-images.githubusercontent.com/120579796/222786015-fae3b0a4-05de-485d-9ded-5a61f0b4e5d6.png)
![Screenshot from 2023-03-03 16-40-37](https://user-images.githubusercontent.com/120579796/222786020-7959644e-05b0-4874-b218-06a09b66b7cb.png)
